### PR TITLE
audio_device: Fix small issues here and there

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -689,7 +689,7 @@ static bool audiod_set_interface(uint8_t rhport, tusb_control_request_t const * 
 
   // Open new EP if necessary - EPs are only to be closed or opened for AS interfaces - Look for AS interface with correct alternate interface
   // Get pointer at end
-  uint8_t const *p_desc_end = _audiod_itf[idxDriver].p_desc + tud_audio_desc_lengths[idxDriver];
+  uint8_t const *p_desc_end = _audiod_itf[idxDriver].p_desc + tud_audio_desc_lengths[idxDriver] - TUD_AUDIO_DESC_IAD_LEN;
 
   // p_desc starts at required interface with alternate setting zero
   while (p_desc < p_desc_end)
@@ -1113,7 +1113,7 @@ static bool audiod_get_AS_interface_index(uint8_t itf, uint8_t *idxDriver, uint8
     if (_audiod_itf[i].p_desc)
     {
       // Get pointer at end
-      uint8_t const *p_desc_end = _audiod_itf[i].p_desc + tud_audio_desc_lengths[i];
+      uint8_t const *p_desc_end = _audiod_itf[i].p_desc + tud_audio_desc_lengths[i] - TUD_AUDIO_DESC_IAD_LEN;
 
       // Advance past AC descriptors
       uint8_t const *p_desc = tu_desc_next(_audiod_itf[i].p_desc);
@@ -1178,7 +1178,7 @@ static bool audiod_verify_itf_exists(uint8_t itf, uint8_t *idxDriver)
     {
       // Get pointer at beginning and end
       uint8_t const *p_desc = _audiod_itf[i].p_desc;
-      uint8_t const *p_desc_end = _audiod_itf[i].p_desc + tud_audio_desc_lengths[i];
+      uint8_t const *p_desc_end = _audiod_itf[i].p_desc + tud_audio_desc_lengths[i] - TUD_AUDIO_DESC_IAD_LEN;
 
       while (p_desc < p_desc_end)
       {

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -1002,10 +1002,10 @@ bool audiod_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint3
       // This is the only place where we can fill something into the EPs buffer!
 
       // Load new data
-      uint16_t *n_bytes_copied = NULL;
-      TU_VERIFY(audio_tx_done_cb(rhport, &_audiod_itf[idxDriver], n_bytes_copied));
+      uint16_t n_bytes_copied;
+      TU_VERIFY(audio_tx_done_cb(rhport, &_audiod_itf[idxDriver], &n_bytes_copied));
 
-      if (*n_bytes_copied == 0)
+      if (n_bytes_copied == 0)
       {
         // Load with ZLP
         return usbd_edpt_xfer(rhport, ep_addr, NULL, 0);

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -171,7 +171,7 @@ uint16_t tud_audio_n_read       (uint8_t itf, uint8_t channelId, void* buffer, u
 void     tud_audio_n_read_flush (uint8_t itf, uint8_t channelId);
 #endif
 
-#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_BUFSIZE
+#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
 uint16_t tud_audio_n_write      (uint8_t itf, uint8_t channelId, uint8_t const* buffer, uint16_t bufsize);
 #endif
 
@@ -194,7 +194,7 @@ inline uint16_t     tud_audio_read       (void* buffer, uint16_t bufsize);
 inline void         tud_audio_read_flush (void);
 #endif
 
-#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_BUFSIZE
+#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
 inline uint16_t tud_audio_write      (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize);
 #endif
 
@@ -263,12 +263,12 @@ inline bool tud_audio_mounted(void)
   return tud_audio_n_mounted(0);
 }
 
-#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_BUFSIZE
+#if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
 inline uint16_t tud_audio_write (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize)    // Short version if only one audio function is used
 {
   return tud_audio_n_write(0, channelId, buffer, bufsize);
 }
-#endif  // CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_BUFSIZE
+#endif  // CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
 
 #if CFG_TUD_AUDIO_EPSIZE_OUT && CFG_TUD_AUDIO_RX_BUFSIZE
 inline uint16_t tud_audio_available(uint8_t channelId)


### PR DESCRIPTION
In several place p_desc_end calculation was not taking into account
that starting pointer (_audiod_itf[idxDriver].p_desc) was pointing
past interface association descriptor.
It would result in accessing random memory.

Other way to fix it would be to store modified length in tud_audio_desc_lengths.