### PR TITLE
UAC2 pre-master

### DIFF
--- a/src/class/audio/audio.h
+++ b/src/class/audio/audio.h
@@ -497,11 +497,13 @@ typedef enum
 /// Isochronous End Point Attributes
 typedef enum
 {
+  TUSB_ISO_EP_ATT_NO_SYNC         = 0x00,
   TUSB_ISO_EP_ATT_ASYNCHRONOUS    = 0x04,
   TUSB_ISO_EP_ATT_ADAPTIVE        = 0x08,
   TUSB_ISO_EP_ATT_SYNCHRONOUS     = 0x0C,
   TUSB_ISO_EP_ATT_DATA            = 0x00, ///< Data End Point
-  TUSB_ISO_EP_ATT_FB              = 0x20, ///< Feedback End Point
+  TUSB_ISO_EP_ATT_EXPLICIT_FB     = 0x10, ///< Feedback End Point
+  TUSB_ISO_EP_ATT_IMPLICIT_FB     = 0x20, ///< Data endpoint that also serves as an implicit feedback
 } tusb_iso_ep_attribute_t;
 
 /// Audio Class-Control Values UAC2

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -48,6 +48,7 @@
 //--------------------------------------------------------------------+
 typedef struct
 {
+  uint8_t rhport;
   uint8_t const * p_desc;       // Pointer pointing to Standard AC Interface Descriptor(4.7.1) - Audio Control descriptor defining audio function
 
 #if CFG_TUD_AUDIO_EPSIZE_IN
@@ -673,6 +674,7 @@ uint16_t audiod_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uin
     if (!_audiod_itf[i].p_desc)
     {
       _audiod_itf[i].p_desc = (uint8_t const *)itf_desc;    // Save pointer to AC descriptor which is by specification always the first one
+      _audiod_itf[i].rhport = rhport;
       break;
     }
   }

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -205,7 +205,7 @@ uint16_t tud_audio_n_read(uint8_t itf, uint8_t channelId, void* buffer, uint16_t
 
 void tud_audio_n_read_flush (uint8_t itf, uint8_t channelId)
 {
-  TU_VERIFY(channelId < CFG_TUD_AUDIO_N_CHANNELS_RX);
+  TU_VERIFY(channelId < CFG_TUD_AUDIO_N_CHANNELS_RX, );
   tu_fifo_clear(&_audiod_itf[itf].rx_ff[channelId]);
 }
 

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -288,7 +288,8 @@ static bool audio_rx_done_type_I_pcm_ff_cb(uint8_t rhport, audiod_interface_t* a
   (void) rhport;
 
   // We expect to get a multiple of CFG_TUD_AUDIO_N_BYTES_PER_SAMPLE_RX * CFG_TUD_AUDIO_N_CHANNELS_RX per channel
-  if (bufsize % CFG_TUD_AUDIO_N_BYTES_PER_SAMPLE_RX*CFG_TUD_AUDIO_N_CHANNELS_RX != 0) {
+  if (bufsize % (CFG_TUD_AUDIO_N_BYTES_PER_SAMPLE_RX * CFG_TUD_AUDIO_N_CHANNELS_RX) != 0)
+  {
     return false;
   }
 

--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -135,7 +135,7 @@ CFG_TUSB_MEM_SECTION audiod_interface_t _audiod_itf[CFG_TUD_AUDIO];
 extern const uint16_t tud_audio_desc_lengths[];
 
 #if CFG_TUD_AUDIO_EPSIZE_OUT
-static audio_rx_done_type_I_pcm_ff_cb(uint8_t rhport, audiod_interface_t* audio, uint8_t const* buffer, uint32_t bufsize);
+static bool audio_rx_done_type_I_pcm_ff_cb(uint8_t rhport, audiod_interface_t* audio, uint8_t * buffer, uint16_t bufsize);
 #endif
 
 #if CFG_TUD_AUDIO_EPSIZE_IN

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -259,6 +259,11 @@ TU_ATTR_WEAK bool tud_audio_rx_done_cb(uint8_t rhport, uint8_t * buffer, uint16_
 
 #if CFG_TUD_AUDIO_EPSIZE_OUT > 0 && CFG_TUD_AUDIO_ENABLE_FEEDBACK_EP
 TU_ATTR_WEAK bool tud_audio_fb_done_cb(uint8_t rhport);
+// User code should call this function with feedback value in 16.16 format for FS and HS.
+// Value will be corrected for FS to 10.14 format automatically.
+// (see Universal Serial Bus Specification Revision 2.0 5.12.4.2).
+// Feedback value will be sent at FB endpoint interval till it's changed.
+bool tud_audio_fb_set(uint8_t rhport, uint32_t feedback);
 #endif
 
 #if CFG_TUD_AUDIO_INT_CTR_EPSIZE_IN

--- a/src/class/audio/audio_device.h
+++ b/src/class/audio/audio_device.h
@@ -196,23 +196,23 @@ uint16_t    tud_audio_int_ctr_n_write       (uint8_t itf, uint8_t const* buffer,
 // Application API (Interface0)
 //--------------------------------------------------------------------+
 
-inline bool         tud_audio_mounted    (void);
+static inline bool         tud_audio_mounted    (void);
 
 #if CFG_TUD_AUDIO_EPSIZE_OUT && CFG_TUD_AUDIO_RX_FIFO_SIZE
-inline uint16_t     tud_audio_available  (void);
-inline uint16_t     tud_audio_read       (void* buffer, uint16_t bufsize);
-inline void         tud_audio_read_flush (void);
+static inline uint16_t     tud_audio_available  (void);
+static inline uint16_t     tud_audio_read       (void* buffer, uint16_t bufsize);
+static inline void         tud_audio_read_flush (void);
 #endif
 
 #if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
-inline uint16_t tud_audio_write      (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize);
+static inline uint16_t tud_audio_write      (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize);
 #endif
 
 #if CFG_TUD_AUDIO_INT_CTR_EPSIZE_IN > 0
-inline uint32_t     tud_audio_int_ctr_available     (void);
-inline uint32_t     tud_audio_int_ctr_read          (void* buffer, uint32_t bufsize);
-inline void         tud_audio_int_ctr_read_flush    (void);
-inline uint32_t     tud_audio_int_ctr_write         (uint8_t const* buffer, uint32_t bufsize);
+static inline uint32_t     tud_audio_int_ctr_available     (void);
+static inline uint32_t     tud_audio_int_ctr_read          (void* buffer, uint32_t bufsize);
+static inline void         tud_audio_int_ctr_read_flush    (void);
+static inline uint32_t     tud_audio_int_ctr_write         (uint8_t const* buffer, uint32_t bufsize);
 #endif
 
 // Buffer control EP data and schedule a transmit
@@ -269,52 +269,52 @@ TU_ATTR_WEAK bool tud_audio_get_req_entity_cb(uint8_t rhport, tusb_control_reque
 // Inline Functions
 //--------------------------------------------------------------------+
 
-inline bool tud_audio_mounted(void)
+static inline bool tud_audio_mounted(void)
 {
   return tud_audio_n_mounted(0);
 }
 
 #if CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
-inline uint16_t tud_audio_write (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize)    // Short version if only one audio function is used
+static inline uint16_t tud_audio_write (uint8_t channelId, uint8_t const* buffer, uint16_t bufsize)    // Short version if only one audio function is used
 {
   return tud_audio_n_write(0, channelId, buffer, bufsize);
 }
 #endif  // CFG_TUD_AUDIO_EPSIZE_IN && CFG_TUD_AUDIO_TX_FIFO_SIZE
 
 #if CFG_TUD_AUDIO_EPSIZE_OUT && CFG_TUD_AUDIO_RX_FIFO_SIZE
-inline uint16_t tud_audio_available(uint8_t channelId)
+static inline uint16_t tud_audio_available(uint8_t channelId)
 {
   return tud_audio_n_available(0, channelId);
 }
 
-inline uint16_t tud_audio_read(uint8_t channelId, void* buffer, uint16_t bufsize)
+static inline uint16_t tud_audio_read(uint8_t channelId, void* buffer, uint16_t bufsize)
 {
   return tud_audio_n_read(0, channelId, buffer, bufsize);
 }
 
-inline void tud_audio_read_flush(uint8_t channelId)
+static inline void tud_audio_read_flush(uint8_t channelId)
 {
   tud_audio_n_read_flush(0, channelId);
 }
 #endif
 
 #if CFG_TUD_AUDIO_INT_CTR_EPSIZE_IN > 0
-inline uint16_t tud_audio_int_ctr_available(void)
+static inline uint16_t tud_audio_int_ctr_available(void)
 {
   return tud_audio_int_ctr_n_available(0);
 }
 
-inline uint16_t tud_audio_int_ctr_read(void* buffer, uint16_t bufsize)
+static inline uint16_t tud_audio_int_ctr_read(void* buffer, uint16_t bufsize)
 {
   return tud_audio_int_ctr_n_read(0, buffer, bufsize);
 }
 
-inline void tud_audio_int_ctr_read_flush(void)
+static inline void tud_audio_int_ctr_read_flush(void)
 {
   return tud_audio_int_ctr_n_read_flush(0);
 }
 
-inline uint16_t tud_audio_int_ctr_write(uint8_t const* buffer, uint16_t bufsize)
+static inline uint16_t tud_audio_int_ctr_write(uint8_t const* buffer, uint16_t bufsize)
 {
   return tud_audio_int_ctr_n_write(0, buffer, bufsize);
 }

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -377,6 +377,11 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 #define TUD_AUDIO_DESC_CS_AS_ISO_EP(_attr, _ctrl, _lockdelayunit, _lockdelay) \
 		TUD_AUDIO_DESC_CS_AS_ISO_EP_LEN, TUSB_DESC_CS_ENDPOINT, AUDIO_CS_EP_SUBTYPE_GENERAL, _attr, _ctrl, _lockdelayunit, U16_TO_U8S_LE(_lockdelay)
 
+/* Standard AS Isochronous Feedback Endpoint Descriptor(4.10.2.1) */
+#define TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN 7
+#define TUD_AUDIO_DESC_STD_AS_ISO_FB_EP(_ep, _interval) \
+		TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN, TUSB_DESC_ENDPOINT, _ep, (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_NO_SYNC | TUSB_ISO_EP_ATT_EXPLICIT_FB), U16_TO_U8S_LE(4), _interval
+
 // AUDIO simple descriptor (UAC2) for 1 microphone input
 // - 1 Input Terminal, 1 Feature Unit (Mute and Volume Control), 1 Output Terminal, 1 Clock Source
 

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -431,6 +431,56 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 		/* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */\
 		TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_UNDEFINED, /*_lockdelay*/ 0x0000)
 
+// AUDIO simple descriptor (UAC2) for mono speaker
+// - 1 Input Terminal, 2 Feature Unit (Mute and Volume Control), 3 Output Terminal, 4 Clock Source
+
+#define TUD_AUDIO_SPEAKER_MONO_FB_DESC_LEN (TUD_AUDIO_DESC_IAD_LEN\
+    + TUD_AUDIO_DESC_STD_AC_LEN\
+    + TUD_AUDIO_DESC_CS_AC_LEN\
+    + TUD_AUDIO_DESC_CLK_SRC_LEN\
+    + TUD_AUDIO_DESC_INPUT_TERM_LEN\
+    + TUD_AUDIO_DESC_OUTPUT_TERM_LEN\
+    + TUD_AUDIO_DESC_FEATURE_UNIT_ONE_CHANNEL_LEN\
+    + TUD_AUDIO_DESC_STD_AS_INT_LEN\
+    + TUD_AUDIO_DESC_STD_AS_INT_LEN\
+    + TUD_AUDIO_DESC_CS_AS_INT_LEN\
+    + TUD_AUDIO_DESC_TYPE_I_FORMAT_LEN\
+    + TUD_AUDIO_DESC_STD_AS_ISO_EP_LEN\
+    + TUD_AUDIO_DESC_CS_AS_ISO_EP_LEN\
+    + TUD_AUDIO_DESC_STD_AS_ISO_FB_EP_LEN)
+
+#define TUD_AUDIO_SPEAKER_MONO_FB_DESCRIPTOR(_itfnum, _stridx, _nBytesPerSample, _nBitsUsedPerSample, _epout, _epsize, _epfb) \
+    /* Standard Interface Association Descriptor (IAD) */\
+    TUD_AUDIO_DESC_IAD(/*_firstitfs*/ _itfnum, /*_nitfs*/ 0x02, /*_stridx*/ 0x00),\
+    /* Standard AC Interface Descriptor(4.7.1) */\
+    TUD_AUDIO_DESC_STD_AC(/*_itfnum*/ _itfnum, /*_nEPs*/ 0x00, /*_stridx*/ _stridx),\
+    /* Class-Specific AC Interface Header Descriptor(4.7.2) */\
+    TUD_AUDIO_DESC_CS_AC(/*_bcdADC*/ 0x0200, /*_category*/ AUDIO_FUNC_DESKTOP_SPEAKER, /*_totallen*/ TUD_AUDIO_DESC_CLK_SRC_LEN+TUD_AUDIO_DESC_INPUT_TERM_LEN+TUD_AUDIO_DESC_OUTPUT_TERM_LEN+TUD_AUDIO_DESC_FEATURE_UNIT_ONE_CHANNEL_LEN, /*_ctrl*/ AUDIO_CS_AS_INTERFACE_CTRL_LATENCY_POS),\
+    /* Clock Source Descriptor(4.7.2.1) */\
+    TUD_AUDIO_DESC_CLK_SRC(/*_clkid*/ 0x04, /*_attr*/ AUDIO_CLOCK_SOURCE_ATT_INT_FIX_CLK, /*_ctrl*/ (AUDIO_CTRL_R << AUDIO_CLOCK_SOURCE_CTRL_CLK_FRQ_POS), /*_assocTerm*/ 0x01,  /*_stridx*/ 0x00),\
+    /* Input Terminal Descriptor(4.7.2.4) */\
+    TUD_AUDIO_DESC_INPUT_TERM(/*_termid*/ 0x01, /*_termtype*/ AUDIO_TERM_TYPE_USB_STREAMING, /*_assocTerm*/ 0x00, /*_clkid*/ 0x04, /*_nchannelslogical*/ 0x01, /*_channelcfg*/ AUDIO_CHANNEL_CONFIG_NON_PREDEFINED, /*_idxchannelnames*/ 0x00, /*_ctrl*/ 0 * (AUDIO_CTRL_R << AUDIO_IN_TERM_CTRL_CONNECTOR_POS), /*_stridx*/ 0x00),\
+    /* Output Terminal Descriptor(4.7.2.5) */\
+    TUD_AUDIO_DESC_OUTPUT_TERM(/*_termid*/ 0x03, /*_termtype*/ AUDIO_TERM_TYPE_OUT_DESKTOP_SPEAKER, /*_assocTerm*/ 0x01, /*_srcid*/ 0x02, /*_clkid*/ 0x04, /*_ctrl*/ 0x0000, /*_stridx*/ 0x00),\
+    /* Feature Unit Descriptor(4.7.2.8) */\
+    TUD_AUDIO_DESC_FEATURE_UNIT_ONE_CHANNEL(/*_unitid*/ 0x02, /*_srcid*/ 0x01, /*_ctrlch0master*/ 0 * (AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_VOLUME_POS), /*_ctrlch1*/ 0 * (AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_MUTE_POS | AUDIO_CTRL_RW << AUDIO_FEATURE_UNIT_CTRL_VOLUME_POS), /*_stridx*/ 0x00),\
+    /* Standard AS Interface Descriptor(4.9.1) */\
+    /* Interface 1, Alternate 0 - default alternate setting with 0 bandwidth */\
+    TUD_AUDIO_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum) + 1), /*_altset*/ 0x00, /*_nEPs*/ 0x00, /*_stridx*/ 0x00),\
+    /* Standard AS Interface Descriptor(4.9.1) */\
+    /* Interface 1, Alternate 1 - alternate interface for data streaming */\
+    TUD_AUDIO_DESC_STD_AS_INT(/*_itfnum*/ (uint8_t)((_itfnum) + 1), /*_altset*/ 0x01, /*_nEPs*/ 0x02, /*_stridx*/ 0x00),\
+    /* Class-Specific AS Interface Descriptor(4.9.2) */\
+    TUD_AUDIO_DESC_CS_AS_INT(/*_termid*/ 0x01, /*_ctrl*/ AUDIO_CTRL_NONE, /*_formattype*/ AUDIO_FORMAT_TYPE_I, /*_formats*/ AUDIO_DATA_FORMAT_TYPE_I_PCM, /*_nchannelsphysical*/ 0x01, /*_channelcfg*/ AUDIO_CHANNEL_CONFIG_NON_PREDEFINED, /*_stridx*/ 0x00),\
+    /* Type I Format Type Descriptor(2.3.1.6 - Audio Formats) */\
+    TUD_AUDIO_DESC_TYPE_I_FORMAT(_nBytesPerSample, _nBitsUsedPerSample),\
+    /* Standard AS Isochronous Audio Data Endpoint Descriptor(4.10.1.1) */\
+    TUD_AUDIO_DESC_STD_AS_ISO_EP(/*_ep*/ _epout, /*_attr*/ (TUSB_XFER_ISOCHRONOUS | TUSB_ISO_EP_ATT_ASYNCHRONOUS | TUSB_ISO_EP_ATT_DATA), /*_maxEPsize*/ _epsize, /*_interval*/ (CFG_TUSB_RHPORT0_MODE & OPT_MODE_HIGH_SPEED) ? 0x04 : 0x01),\
+    /* Class-Specific AS Isochronous Audio Data Endpoint Descriptor(4.10.1.2) */\
+    TUD_AUDIO_DESC_CS_AS_ISO_EP(/*_attr*/ AUDIO_CS_AS_ISO_DATA_EP_ATT_NON_MAX_PACKETS_OK, /*_ctrl*/ AUDIO_CTRL_NONE, /*_lockdelayunit*/ AUDIO_CS_AS_ISO_DATA_EP_LOCK_DELAY_UNIT_UNDEFINED, /*_lockdelay*/ 0x0000),\
+    /* Standard AS Isochronous Feedback Endpoint Descriptor(4.10.2.1) */\
+    TUD_AUDIO_DESC_STD_AS_ISO_FB_EP(/*_ep*/ _epfb, /*_interval*/ 1)\
+
 //------------- TUD_USBTMC/USB488 -------------//
 #define TUD_USBTMC_APP_CLASS    (TUSB_CLASS_APPLICATION_SPECIFIC)
 #define TUD_USBTMC_APP_SUBCLASS 0x03u

--- a/src/portable/st/synopsys/dcd_synopsys.c
+++ b/src/portable/st/synopsys/dcd_synopsys.c
@@ -809,20 +809,7 @@ static void dcd_edpt_disable (uint8_t rhport, uint8_t ep_addr, bool stall)
  */
 void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr)
 {
-  USB_OTG_GlobalTypeDef * usb_otg = GLOBAL_BASE(rhport);
-
-  uint8_t const epnum = tu_edpt_number(ep_addr);
-  uint8_t const dir   = tu_edpt_dir(ep_addr);
-
   dcd_edpt_disable(rhport, ep_addr, false);
-//  if (dir == TUSB_DIR_IN)
-//  {
-//    uint16_t const fifo_size = (usb_otg->DIEPTXF[epnum - 1] & USB_OTG_DIEPTXF_INEPTXFD_Msk) >> USB_OTG_DIEPTXF_INEPTXFD_Pos;
-//    uint16_t const fifo_start = (usb_otg->DIEPTXF[epnum - 1] & USB_OTG_DIEPTXF_INEPTXSA_Msk) >> USB_OTG_DIEPTXF_INEPTXSA_Pos;
-//    // For now only endpoint that has FIFO at the end of FIFO memory can be closed without fuss.
-//    TU_ASSERT(fifo_start + fifo_size == _allocated_fifo_words,);
-//    _allocated_fifo_words -= fifo_size;
-//  }
 }
 
 void dcd_edpt_stall (uint8_t rhport, uint8_t ep_addr)


### PR DESCRIPTION
**Describe the PR**
Various changes that allow to build speaker part of UAC2.
Example descriptor provided only for mono speaker.
Small fixes to audio device code and synopsys driver.

**Additional context**
Tested to create stereo and mono speaker (with and without explicit feedback).
Tested to create stereo microphone.
Tested code was using PCM 16 bits samples with FIFOs (both per channel and single FIFO).
No direct writes to endpoint buffer were tested here.
Code was tested on STM32F411RE MCU, with mynewt that provides support for I2S.